### PR TITLE
Add packaging metadata and wrapper modules

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.gtmo_core_v2')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)

--- a/gtmo/__init__.py
+++ b/gtmo/__init__.py
@@ -1,0 +1,9 @@
+"""GTMØ package with optimized modules."""
+
+__all__ = [
+    "gtmo_core_v2",
+    "topology_v2_optimized",
+    "gtmo_axioms_v2",
+    "utils_v2",
+    "gtmo_interop_v3",
+]

--- a/gtmo_axioms.py
+++ b/gtmo_axioms.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.gtmo_axioms_v2')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)

--- a/gtmo_axioms_v2.py
+++ b/gtmo_axioms_v2.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.gtmo_axioms_v2')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)

--- a/gtmo_core_v2.py
+++ b/gtmo_core_v2.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.gtmo_core_v2')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)

--- a/gtmo_interop_v3.py
+++ b/gtmo_interop_v3.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.gtmo_interop_v3')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gtmo"
+version = "0.1.0"
+description = "Generalized Theory of Mathematical Indefiniteness library"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{name = "GTMØ Contributors"}]
+license = {text = "MIT"}
+dependencies = ["numpy>=1.23.0,<2.0.0"]
+
+[project.optional-dependencies]
+torch = ["torch"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["gtmo*"]
+
+[tool.setuptools]
+py-modules = [
+    "core",
+    "gtmo_core_v2",
+    "gtmo_axioms",
+    "gtmo_axioms_v2",
+    "gtmo_interop_v3",
+    "topology",
+    "utils",
+]

--- a/topology.py
+++ b/topology.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.topology_v2_optimized')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,5 @@
+from importlib import import_module
+_impl = import_module('gtmo.utils_v2')
+__all__ = [name for name in dir(_impl) if not name.startswith('_')]
+for name in __all__:
+    globals()[name] = getattr(_impl, name)


### PR DESCRIPTION
## Summary
- add `pyproject.toml` for setuptools
- expose convenience wrappers (`core.py`, `gtmo_core_v2.py`, etc.)
- keep `gtmo/__init__` minimal

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ImportError cannot import name 'ThresholdManager')*

------
https://chatgpt.com/codex/tasks/task_e_6859be4cd6888328a4ade7efe882e424